### PR TITLE
Ajustando testes para a novas versões do PHP

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,8 @@ php:
 - 5.6
 - 7.1
 - 7.2
-- 7.3
+- 7.3.24
+- 7.4
 
 # Note: Code coverage requires php-xDebug extension enabled on CI server
 


### PR DESCRIPTION
- Adicionando a versão 7.4 do PHP nos testes